### PR TITLE
Fix for ZFS enumeration

### DIFF
--- a/custom_components/openmediavault/helper.py
+++ b/custom_components/openmediavault/helper.py
@@ -76,8 +76,12 @@ def parse_api(
         if key or key_search:
             uid = get_uid(entry, key, key_secondary, key_search, keymap)
             if not uid:
-                continue
-
+                # ZFS filesystems don't have a UUID, so use devicefile instead.
+                if entry["type"] == "zfs":
+                    uid = entry["devicefile"]
+                    entry["uuid"] = uid
+                else:
+                    continue
             if uid not in data:
                 data[uid] = {}
 


### PR DESCRIPTION
This should fix #22 

## Proposed change
As explained in the linked issue, ZFS filesystems don't properly enumerate since the OMV api returns a null ```uuid``` for zfs file systems and this plugin effectively skips anything with a null ```uuid```.  I made a change where ```devicefile``` would be used in place of ```uuid``` as the key for these zfs cases only.  Please let me know if this approach is not preferred!

I have tested this change on my local instance of home assistant (see screenshot of the entity below).

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Here's a screenshot of the newly created entity in my local HA instance:
![example](https://user-images.githubusercontent.com/6874114/104690976-67883500-56d3-11eb-97fc-f1a8280e8911.PNG)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
