### PR TITLE
update uptime reading for OMV 6.x

### DIFF
--- a/custom_components/openmediavault/omv_controller.py
+++ b/custom_components/openmediavault/omv_controller.py
@@ -1,6 +1,7 @@
 """OpenMediaVault Controller."""
 
 import asyncio
+import time
 from datetime import timedelta
 
 from homeassistant.const import (
@@ -168,7 +169,22 @@ class OMVControllerData(object):
             ensure_vals=[{"name": "memUsage", "default": 0}],
         )
 
-        tmp = self.data["hwinfo"]["uptime"].split(" ")
+        if int(self.data["hwinfo"]["version"].split(".")[0])>5:
+            tmp = self.data["hwinfo"]["uptime"]
+            pos = abs( int(tmp) )
+            day = pos / (3600*24)
+            rem = pos % (3600*24)
+            hour = rem / 3600
+            rem = rem % 3600
+            mins = rem / 60
+            secs = rem % 60
+            res = '%d days %02d hours %02d minutes %02d seconds' % (day, hour, mins, secs)
+            if int(tmp) < 0:
+                res = "-%s" % res
+            tmp = res.split(" ")
+        else:
+            tmp = self.data["hwinfo"]["uptime"].split(" ")
+            
         self.data["hwinfo"]["uptimeEpoch"] = int(tmp[0]) * 24 + int(tmp[2])
         self.data["hwinfo"]["cpuUsage"] = round(self.data["hwinfo"]["cpuUsage"], 1)
         if int(self.data["hwinfo"]["memTotal"]) > 0:


### PR DESCRIPTION
In OMV 6.x update is shown as:
'uptime': 873077.17
instead of previously in OMV 5.x as:
'uptime': '14 days 0 hours 14 minutes 49 seconds'

## Proposed change
<!--
  Describe the big picture of your changes here. If it fixes a bug
  or resolves a feature request, be sure to link to that issue.
-->


## Type of change
<!--
  What type of change does your PR introduces?
-->
- [ ] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [ ] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
