### PR TITLE
chore: add "seconds" to scan interval display for clarity

### DIFF
--- a/custom_components/openmediavault/omv_controller.py
+++ b/custom_components/openmediavault/omv_controller.py
@@ -89,7 +89,7 @@ class OMVControllerData(object):
     # ---------------------------
     @property
     def option_scan_interval(self):
-        """Config entry option scan interval."""
+        """Config entry option scan interval (seconds)."""
         scan_interval = self.config_entry.options.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
         )

--- a/custom_components/openmediavault/strings.json
+++ b/custom_components/openmediavault/strings.json
@@ -32,7 +32,7 @@
         "step": {
             "basic_options": {
                 "data": {
-                    "scan_interval": "Scan interval",
+                    "scan_interval": "Scan interval (seconds)",
                     "smart_disable": "Disable S.M.A.R.T."
                 },
                 "title": "OpenMediaVault options",

--- a/custom_components/openmediavault/translations/en.json
+++ b/custom_components/openmediavault/translations/en.json
@@ -32,7 +32,7 @@
         "step": {
             "basic_options": {
                 "data": {
-                    "scan_interval": "Scan interval",
+                    "scan_interval": "Scan interval (seconds)",
                     "smart_disable": "Disable S.M.A.R.T."
                 },
                 "title": "OpenMediaVault options",

--- a/custom_components/openmediavault/translations/nl.json
+++ b/custom_components/openmediavault/translations/nl.json
@@ -32,7 +32,7 @@
         "step": {
             "basic_options": {
                 "data": {
-                    "scan_interval": "Scan interval",
+                    "scan_interval": "Scan interval (seconds)",
                     "smart_disable": "Disable S.M.A.R.T."
                 },
                 "title": "OpenMediaVault options",

--- a/custom_components/openmediavault/translations/pt_BR.json
+++ b/custom_components/openmediavault/translations/pt_BR.json
@@ -32,7 +32,7 @@
         "step": {
             "basic_options": {
                 "data": {
-                    "scan_interval": "Scan interval",
+                    "scan_interval": "Scan interval (seconds)",
                     "smart_disable": "Disable S.M.A.R.T."
                 },
                 "title": "OpenMediaVault options",

--- a/custom_components/openmediavault/translations/sv_SE.json
+++ b/custom_components/openmediavault/translations/sv_SE.json
@@ -32,7 +32,7 @@
         "step": {
             "basic_options": {
                 "data": {
-                    "scan_interval": "Scan interval",
+                    "scan_interval": "Scan interval (seconds)",
                     "smart_disable": "Disable S.M.A.R.T."
                 },
                 "title": "OpenMediaVault options",


### PR DESCRIPTION
## Proposed change
The scan interval option has no tooltip for what the number means.
By adding "(seconds)" it's much clearer to the user that the interval is mentioned in seconds and not minutes.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
