### PR TITLE
Add SMART overall drive health to "disk" entry

### DIFF
--- a/custom_components/openmediavault/omv_controller.py
+++ b/custom_components/openmediavault/omv_controller.py
@@ -335,6 +335,7 @@ class OMVControllerData(object):
             key="devicename",
             vals=[
                 {"name": "temperature", "default": 0},
+                {"name": "overallstatus", "default": "unknown"},
             ],
         )
 

--- a/custom_components/openmediavault/sensor_types.py
+++ b/custom_components/openmediavault/sensor_types.py
@@ -51,6 +51,7 @@ DEVICE_ATTRIBUTES_DISK = [
     "israid",
     "isroot",
     "isreadonly",
+    "overallstatus",
 ]
 
 DEVICE_ATTRIBUTES_DISK_SMART = [


### PR DESCRIPTION
## Proposed change

Add SMART overall drive health to "disk" entry. Fix from @rofo69 from https://community.home-assistant.io/t/openmediavault-integration/189310/156

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [X] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [X] The code change is tested and works locally.
- [X] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
